### PR TITLE
PEGASUS: Remove duplicate windows/dvd detection entry

### DIFF
--- a/engines/pegasus/detection.cpp
+++ b/engines/pegasus/detection.cpp
@@ -122,18 +122,6 @@ static const PegasusGameDescription gameDescriptions[] = {
 			"DVD",
 			AD_ENTRY1s("JMP PP Resources", "d13a602d2498010d720a6534f097f88b", 2075337),
 			Common::EN_ANY,
-			Common::kPlatformWindows,
-			ADGF_MACRESFORK|GF_DVD,
-			GUIO0()
-		},
-	},
-
-	{
-		{
-			"pegasus",
-			"DVD",
-			AD_ENTRY1s("JMP PP Resources", "d13a602d2498010d720a6534f097f88b", 2075337),
-			Common::EN_ANY,
 			Common::kPlatformLinux,
 			ADGF_MACRESFORK|GF_DVD,
 			GUIO0()


### PR DESCRIPTION
There are 2 entries for the windows dvd version so I deleted one of them.